### PR TITLE
Add index.d.ts types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export function isElevated(): boolean;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "Native module for checking if the process is being run with elevated privileges",
   "main": "index.js",
+  "types": "index.d.ts",
   "engine": {
     "node": ">=4.0.0"
   },


### PR DESCRIPTION
This allows VSCode to remove its copy of `native-is-elevated.d.ts`.

Refs: microsoft/vscode#83421