### PR TITLE
export function directly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export function isElevated(): boolean;
+declare function isElevated(): boolean;
+
+export = isElevated;


### PR DESCRIPTION
@arkon sorry I think my types were wrong, it looks like this module exports its function directly. To test this I installed 0.4.0 freshly and tried it out:

![image](https://user-images.githubusercontent.com/900690/68457984-f95bfe80-0201-11ea-8de4-ed1e7b1aa057.png)
