### PR TITLE
Fix for building with Electron Builder

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "openssl_fips" : "0" 
+  },
   "targets": [
     {
       "target_name": "iselevated",


### PR DESCRIPTION
Fixes `npm ERR! gyp: name 'openssl_fips' is not defined while evaluating condition 'openssl_fips != ""' in binding.gyp while trying to load binding.gyp`

And removes the need to add `--openssl_fips=''` to npm commands that call Electron Builder (e.g: `npm run dist --openssl_fips=''` when `dist` is set to run `electron-builder` in the `package.json` file)