### PR TITLE
Add additional flags for security

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,13 +1,31 @@
 {
   "variables": {
-    "openssl_fips" : "0" 
+    "openssl_fips" : "0"
   },
   "targets": [
     {
       "target_name": "iselevated",
       "sources": [
         "src/iselevated.cc"
-      ]
+      ],
+      "msvs_configuration_attributes": {
+        "SpectreMitigation": "Spectre"
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
+            "/guard:cf",
+            "/we4244",
+            "/we4267",
+            "/ZH:SHA_256"
+          ]
+        },
+        "VCLinkerTool": {
+          "AdditionalOptions": [
+            "/guard:cf"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Hi! We're currently using native-is-elevated in VS Code.
This PR adds additional flags for node-gyp in accordance with [microsoft/binskim](https://github.com/microsoft/binskim) policies.